### PR TITLE
Fix GitHub Action version tag from v1 to v1.5.0

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: project-env/project-env-github-action@v1
+      - uses: project-env/project-env-github-action@v1.5.0
         with:
           cli-version: '3.12.2'
 

--- a/src/content/docs/integrations/github-action.mdx
+++ b/src/content/docs/integrations/github-action.mdx
@@ -27,7 +27,7 @@ Whether to activate the debug mode of the [Project-Env CLI](https://github.com/P
 steps:
   - uses: actions/checkout@v4
 
-  - uses: project-env/project-env-github-action@v1
+  - uses: project-env/project-env-github-action@v1.5.0
     with:
       cli-version: '3.26.0'
 


### PR DESCRIPTION
The action repository does not have a v1 major version tag, only exact version tags (v1.0.0 through v1.5.0).